### PR TITLE
Update pom.xml

### DIFF
--- a/MavenProject/multi1/pom.xml
+++ b/MavenProject/multi1/pom.xml
@@ -80,8 +80,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
-            <version>5.9</version>
+            <classifier>jdk18</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fix for jdk 1.5 Compailation error 
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
[INFO] 2 errors 
[INFO] --------------------